### PR TITLE
traversable: remove assumption that ‘F’ is equivalent to ‘of(F)’

### DIFF
--- a/src/Traversable.js
+++ b/src/Traversable.js
@@ -20,11 +20,12 @@ module.exports = function(equals) {
                     traverse(G)(t)(u));
     }),
 
-    //  traverse F F u = of F u
+    //  traverse F pure u = pure u
     identity: assert.forall2(function(F, u) {
+      var pure = of(F);
       return Z.Traversable.test(u) &&
-             equals(traverse(F)(F)(u),
-                    of(F)(u));
+             equals(traverse(F)(pure)(u),
+                    pure(u));
     }),
 
     //  traverse C C u = C (traverse G identity <$> traverse F identity u)


### PR DESCRIPTION
Commit message:

> This assumption may hold for some types with one data constructor, but it will not hold for types with more than one data constructor.

I've lost track of the number of hours I've spent looking at these laws. They *still* confuse me. :thinking:

/cc @Avaq
