### PR TITLE
sanctuary-type-classes@8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "fantasy-land": "3.5.x",
     "jsverify": "0.8.x",
-    "sanctuary-type-classes": "8.1.x"
+    "sanctuary-type-classes": "8.1.1"
   },
   "devDependencies": {
     "sanctuary-scripts": "1.0.x"


### PR DESCRIPTION
The [v8.1.1 release][1] is crucial for this project as it fixes the handling of `NaN` in [`Z.lte`][2]. Without this fix a project testing the lawfulness of `Arbitrary (Identity Number)` would run into problems if `Identity (NaN)` is produced by the arbitrary. See sanctuary-js/sanctuary-type-classes#88 for details.

/cc @Avaq, @CrossEye


[1]: https://github.com/sanctuary-js/sanctuary-type-classes/releases/tag/v8.1.1
[2]: https://github.com/sanctuary-js/sanctuary-type-classes/tree/v8.1.1#lte
