### PR TITLE
use sanctuary-show for string representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ algebraic data types.
 
 ## Installation
 
-Add `fantasy-laws`, [`jsverify`][2], and [`sanctuary-type-classes`][3] to
-`"devDependencies"` in __package.json__, then run `npm install`.
+Add `fantasy-laws`, [`jsverify`][2], [`sanctuary-show`][3], and
+[`sanctuary-type-classes`][4] to `"devDependencies"` in __package.json__,
+then run `npm install`.
 
 ## Usage
 
@@ -40,11 +41,13 @@ Sum.prototype['fantasy-land/invert'] = function() {
 
 The following steps demonstrate how to test the Group laws:
 
-1.  Require `fantasy-laws`, `jsverify`, and `sanctuary-type-classes`:
+1.  Require `fantasy-laws`, `jsverify`, `sanctuary-show`, and
+    `sanctuary-type-classes`:
 
     ```javascript
     const laws = require ('fantasy-laws');
     const jsc = require ('jsverify');
+    const show = require ('sanctuary-show');
     const Z = require ('sanctuary-type-classes');
     ```
 
@@ -54,11 +57,11 @@ The following steps demonstrate how to test the Group laws:
     const Sum = require ('../Sum');
     ```
 
-3.  Define an ["arbitrary"][4] for the type:
+3.  Define an ["arbitrary"][5] for the type:
 
     ```javascript
     //    SumArb :: Arbitrary Sum
-    const SumArb = jsc.number.smap (Sum, sum => sum.value, Z.toString);
+    const SumArb = jsc.number.smap (Sum, sum => sum.value, show);
     ```
 
 4.  Provide the fixed parameters to `laws.Group`:
@@ -90,5 +93,6 @@ The following steps demonstrate how to test the Group laws:
 
 [1]: https://github.com/fantasyland/fantasy-land
 [2]: https://github.com/jsverify/jsverify
-[3]: https://github.com/sanctuary-js/sanctuary-type-classes
-[4]: https://github.com/jsverify/jsverify#arbitrary-data
+[3]: https://github.com/sanctuary-js/sanctuary-show
+[4]: https://github.com/sanctuary-js/sanctuary-type-classes
+[5]: https://github.com/jsverify/jsverify#arbitrary-data

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "fantasy-land": "3.5.x",
     "jsverify": "0.8.x",
+    "sanctuary-show": "1.0.0",
     "sanctuary-type-classes": "8.1.1"
   },
   "devDependencies": {

--- a/src/internal/Compose.js
+++ b/src/internal/Compose.js
@@ -1,6 +1,9 @@
 'use strict';
 
+var util = require ('util');
+
 var FL = require ('fantasy-land');
+var show = require ('sanctuary-show');
 var Z = require ('sanctuary-type-classes');
 
 var ap = require ('./ap');
@@ -41,11 +44,13 @@ module.exports = curry2 (function(F, G) {
              typeRep.name;
   }
 
-  Compose.prototype.inspect =
-  Compose.prototype.toString = function() {
-    return 'Compose(' + name (F) + ')' +
-                  '(' + name (G) + ')' +
-                  '(' + Z.toString (this.value) + ')';
+  var inspect = typeof util.inspect.custom === 'symbol' ? util.inspect.custom
+                                                        : 'inspect';
+  Compose.prototype[inspect] =
+  Compose.prototype['@@show'] = function() {
+    return 'Compose (' + name (F) + ')' +
+                  ' (' + name (G) + ')' +
+                  ' (' + show (this.value) + ')';
   };
 
   return Compose;


### PR DESCRIPTION
[`show`][1] replaces [`Z.toString`][2].


[1]: https://github.com/sanctuary-js/sanctuary-show#show
[2]: https://github.com/sanctuary-js/sanctuary-type-classes/tree/v8.1.1#toString
