### PR TITLE
Support asynchronous equality functions

### DIFF
--- a/src/internal/assert.js
+++ b/src/internal/assert.js
@@ -6,7 +6,7 @@ var jsc = require ('jsverify');
 exports.forall1 = function(property) {
   return function(A) {
     return function() {
-      jsc.assert (jsc.forall (A, property));
+      return jsc.assert (jsc.forall (A, property));
     };
   };
 };
@@ -14,7 +14,7 @@ exports.forall1 = function(property) {
 exports.forall2 = function(property) {
   return function(A, B) {
     return function() {
-      jsc.assert (jsc.forall (A, B, property));
+      return jsc.assert (jsc.forall (A, B, property));
     };
   };
 };
@@ -22,7 +22,7 @@ exports.forall2 = function(property) {
 exports.forall3 = function(property) {
   return function(A, B, C) {
     return function() {
-      jsc.assert (jsc.forall (A, B, C, property));
+      return jsc.assert (jsc.forall (A, B, C, property));
     };
   };
 };
@@ -30,7 +30,7 @@ exports.forall3 = function(property) {
 exports.forall4 = function(property) {
   return function(A, B, C, D) {
     return function() {
-      jsc.assert (jsc.forall (A, B, C, D, property));
+      return jsc.assert (jsc.forall (A, B, C, D, property));
     };
   };
 };
@@ -38,7 +38,7 @@ exports.forall4 = function(property) {
 exports.forall5 = function(property) {
   return function(A, B, C, D, E) {
     return function() {
-      jsc.assert (jsc.forall (A, B, C, D, E, property));
+      return jsc.assert (jsc.forall (A, B, C, D, E, property));
     };
   };
 };


### PR DESCRIPTION
Testing the algebraic properties of Fluture could be done more robustly when the FutureArb's I'm passing are possibly asynchronous.

JSVerify supports async properties (handles returned Promises), and since it's already possible to customize the `equals` function such that it returns a Promise, the only missing element to make things work with Fantasy Laws is to return the result from `jsc.assert`.

This change ensures that jsverify's Promises are passed down, so that they can be handled by the party receiving them.