### PR TITLE
use ES modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,10 @@
 {
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint-es6.json"],
+  "parserOptions": {"ecmaVersion": 2020, "sourceType": "module"},
   "env": {"node": true},
   "rules": {
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "imports": "always-multiline", "exports": "always-multiline", "functions": "never"}],
     "max-len": ["off"]
-  },
-  "overrides": [
-    {
-      "files": ["*.md"],
-      "rules": {
-        "no-undef": ["off"],
-        "no-unused-vars": ["off"]
-      }
-    }
-  ]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -41,20 +41,20 @@ Sum.prototype['fantasy-land/invert'] = function() {
 
 The following steps demonstrate how to test the Group laws:
 
-1.  Require `fantasy-laws`, `jsverify`, `sanctuary-show`, and
+1.  Import `fantasy-laws`, `jsverify`, `sanctuary-show`, and
     `sanctuary-type-classes`:
 
     ```javascript
-    const laws = require ('fantasy-laws');
-    const jsc = require ('jsverify');
-    const show = require ('sanctuary-show');
-    const Z = require ('sanctuary-type-classes');
+    import laws from 'fantasy-laws';
+    import jsc from 'jsverify';
+    import show from 'sanctuary-show';
+    import Z from 'sanctuary-type-classes';
     ```
 
-2.  Require the type to be tested:
+2.  Import the type to be tested:
 
     ```javascript
-    const Sum = require ('../Sum');
+    import Sum from '../Sum.js';
     ```
 
 3.  Define an ["arbitrary"][5] for the type:

--- a/index.js
+++ b/index.js
@@ -1,28 +1,52 @@
-'use strict';
+import Alt from './src/Alt.js';
+import Alternative from './src/Alternative.js';
+import Applicative from './src/Applicative.js';
+import Apply from './src/Apply.js';
+import Bifunctor from './src/Bifunctor.js';
+import Category from './src/Category.js';
+import Chain from './src/Chain.js';
+import ChainRec from './src/ChainRec.js';
+import Comonad from './src/Comonad.js';
+import Contravariant from './src/Contravariant.js';
+import Extend from './src/Extend.js';
+import Filterable from './src/Filterable.js';
+import Foldable from './src/Foldable.js';
+import Functor from './src/Functor.js';
+import Group from './src/Group.js';
+import Monad from './src/Monad.js';
+import Monoid from './src/Monoid.js';
+import Ord from './src/Ord.js';
+import Plus from './src/Plus.js';
+import Profunctor from './src/Profunctor.js';
+import Semigroup from './src/Semigroup.js';
+import Semigroupoid from './src/Semigroupoid.js';
+import Setoid from './src/Setoid.js';
+import Traversable from './src/Traversable.js';
 
-module.exports = {
-  Alt: require ('./src/Alt'),
-  Alternative: require ('./src/Alternative'),
-  Applicative: require ('./src/Applicative'),
-  Apply: require ('./src/Apply'),
-  Bifunctor: require ('./src/Bifunctor'),
-  Category: require ('./src/Category'),
-  Chain: require ('./src/Chain'),
-  ChainRec: require ('./src/ChainRec'),
-  Comonad: require ('./src/Comonad'),
-  Contravariant: require ('./src/Contravariant'),
-  Extend: require ('./src/Extend'),
-  Filterable: require ('./src/Filterable'),
-  Foldable: require ('./src/Foldable'),
-  Functor: require ('./src/Functor'),
-  Group: require ('./src/Group'),
-  Monad: require ('./src/Monad'),
-  Monoid: require ('./src/Monoid'),
-  Ord: require ('./src/Ord'),
-  Plus: require ('./src/Plus'),
-  Profunctor: require ('./src/Profunctor'),
-  Semigroup: require ('./src/Semigroup'),
-  Semigroupoid: require ('./src/Semigroupoid'),
-  Setoid: require ('./src/Setoid'),
-  Traversable: require ('./src/Traversable'),
+
+export default {
+  Alt,
+  Alternative,
+  Applicative,
+  Apply,
+  Bifunctor,
+  Category,
+  Chain,
+  ChainRec,
+  Comonad,
+  Contravariant,
+  Extend,
+  Filterable,
+  Foldable,
+  Functor,
+  Group,
+  Monad,
+  Monoid,
+  Ord,
+  Plus,
+  Profunctor,
+  Semigroup,
+  Semigroupoid,
+  Setoid,
+  Traversable,
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.3.0",
   "description": "Property-based tests for Fantasy Land -compliant algebraic data types",
   "license": "MIT",
+  "type": "module",
+  "main": "./index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/fantasyland/fantasy-laws.git"

--- a/src/Alt.js
+++ b/src/Alt.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const alt = require ('./internal/alt');
-const assert = require ('./internal/assert');
-const map = require ('./internal/map');
+import alt from './internal/alt.js';
+import assert from './internal/assert.js';
+import map from './internal/map.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (a <|> b) <|> c = a <|> (b <|> c)
   associativity: assert.forall3 (a => b => c =>

--- a/src/Alternative.js
+++ b/src/Alternative.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const alt = require ('./internal/alt');
-const ap = require ('./internal/ap');
-const assert = require ('./internal/assert');
+import alt from './internal/alt.js';
+import ap from './internal/ap.js';
+import assert from './internal/assert.js';
 
 
-module.exports = (equals, A) => {
+export default (equals, A) => {
   const zero = Z.zero (A);
   return {
 

--- a/src/Applicative.js
+++ b/src/Applicative.js
@@ -1,15 +1,13 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const $ = require ('./internal/$');
-const ap = require ('./internal/ap');
-const assert = require ('./internal/assert');
-const identity = require ('./internal/identity');
-const of = require ('./internal/of');
+import $ from './internal/$.js';
+import ap from './internal/ap.js';
+import assert from './internal/assert.js';
+import identity from './internal/identity.js';
+import of from './internal/of.js';
 
 
-module.exports = (equals, A) => {
+export default (equals, A) => {
   const pure = of (A);
   return {
 

--- a/src/Apply.js
+++ b/src/Apply.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const ap = require ('./internal/ap');
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const map = require ('./internal/map');
+import ap from './internal/ap.js';
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import map from './internal/map.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (.) <$> u <*> v <*> w = u <*> (v <*> w)
   composition: assert.forall3 (u => v => w =>

--- a/src/Bifunctor.js
+++ b/src/Bifunctor.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const bimap = require ('./internal/bimap');
-const compose = require ('./internal/compose_');
-const identity = require ('./internal/identity');
+import assert from './internal/assert.js';
+import bimap from './internal/bimap.js';
+import compose from './internal/compose_.js';
+import identity from './internal/identity.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  bimap identity identity p = p
   identity: assert.forall1 (p =>

--- a/src/Category.js
+++ b/src/Category.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const id = require ('./internal/id');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import id from './internal/id.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  a `compose` id C = a
   leftIdentity: assert.forall2 (C => a =>

--- a/src/Chain.js
+++ b/src/Chain.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const chain = require ('./internal/chain');
-const composeK = require ('./internal/composeK');
+import assert from './internal/assert.js';
+import chain from './internal/chain.js';
+import composeK from './internal/composeK.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (m >>= f) >>= g = m >>= (f >=> g)
   associativity: assert.forall3 (m => f => g =>

--- a/src/ChainRec.js
+++ b/src/ChainRec.js
@@ -1,12 +1,10 @@
-'use strict';
-
-const assert = require ('./internal/assert');
-const chain = require ('./internal/chain');
-const chainRec = require ('./internal/chainRec');
-const map = require ('./internal/map');
+import assert from './internal/assert.js';
+import chain from './internal/chain.js';
+import chainRec from './internal/chainRec.js';
+import map from './internal/map.js';
 
 
-module.exports = (equals, CR) => ({
+export default (equals, CR) => ({
 
   equivalence: assert.forall4 (p => n => d => i =>
     equals (chainRec (CR) ((next, done, v) => p (v) ? map (done) (d (v)) : map (next) (n (v))) (i),

--- a/src/Comonad.js
+++ b/src/Comonad.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const extend = require ('./internal/extend');
-const extract = require ('./internal/extract');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import extend from './internal/extend.js';
+import extract from './internal/extract.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  extend extract w = w
   leftIdentity: assert.forall1 (w =>

--- a/src/Contravariant.js
+++ b/src/Contravariant.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const contramap = require ('./internal/contramap');
-const identity = require ('./internal/identity');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import contramap from './internal/contramap.js';
+import identity from './internal/identity.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  contramap identity u = u
   identity: assert.forall1 (u =>

--- a/src/Extend.js
+++ b/src/Extend.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const extend = require ('./internal/extend');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import extend from './internal/extend.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (extend f . extend g) w = extend (f . extend g) w
   associativity: assert.forall3 (w => f => g =>

--- a/src/Filterable.js
+++ b/src/Filterable.js
@@ -1,12 +1,10 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const filter = require ('./internal/filter');
+import assert from './internal/assert.js';
+import filter from './internal/filter.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  filter (\x -> p x && q x) v = filter q (filter p v)
   distributivity: assert.forall3 (v => p => q =>

--- a/src/Foldable.js
+++ b/src/Foldable.js
@@ -1,12 +1,10 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const reduce = require ('./internal/reduce');
+import assert from './internal/assert.js';
+import reduce from './internal/reduce.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  reduce f x u = reduce f x (reduce (\xs x -> xs ++ [x]) [] u)
   associativity: assert.forall3 (f => x => u =>

--- a/src/Functor.js
+++ b/src/Functor.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const identity = require ('./internal/identity');
-const map = require ('./internal/map');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import identity from './internal/identity.js';
+import map from './internal/map.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  identity <$> u = u
   identity: assert.forall1 (u =>

--- a/src/Group.js
+++ b/src/Group.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const concat = require ('./internal/concat');
-const invert = require ('./internal/invert');
+import assert from './internal/assert.js';
+import concat from './internal/concat.js';
+import invert from './internal/invert.js';
 
 
-module.exports = (equals, G) => {
+export default (equals, G) => {
   const empty = Z.empty (G);
   return {
 

--- a/src/Monad.js
+++ b/src/Monad.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const chain = require ('./internal/chain');
-const of = require ('./internal/of');
+import assert from './internal/assert.js';
+import chain from './internal/chain.js';
+import of from './internal/of.js';
 
 
-module.exports = (equals, M) => {
+export default (equals, M) => {
   const pure = of (M);
   return {
 

--- a/src/Monoid.js
+++ b/src/Monoid.js
@@ -1,12 +1,10 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const concat = require ('./internal/concat');
+import assert from './internal/assert.js';
+import concat from './internal/concat.js';
 
 
-module.exports = (equals, M) => {
+export default (equals, M) => {
   const empty = Z.empty (M);
   return {
 

--- a/src/Ord.js
+++ b/src/Ord.js
@@ -1,11 +1,9 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
+import assert from './internal/assert.js';
 
 
-module.exports = {
+export default {
 
   //  a `lte` b || b `lte` a
   totality: assert.forall2 (a => b =>

--- a/src/Plus.js
+++ b/src/Plus.js
@@ -1,13 +1,11 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const alt = require ('./internal/alt');
-const assert = require ('./internal/assert');
-const map = require ('./internal/map');
+import alt from './internal/alt.js';
+import assert from './internal/assert.js';
+import map from './internal/map.js';
 
 
-module.exports = (equals, P) => {
+export default (equals, P) => {
   const zero = Z.zero (P);
   return {
 

--- a/src/Profunctor.js
+++ b/src/Profunctor.js
@@ -1,14 +1,12 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
-const identity = require ('./internal/identity');
-const promap = require ('./internal/promap');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
+import identity from './internal/identity.js';
+import promap from './internal/promap.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  promap identity identity p = p
   identity: assert.forall1 (p =>

--- a/src/Semigroup.js
+++ b/src/Semigroup.js
@@ -1,12 +1,10 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const concat = require ('./internal/concat');
+import assert from './internal/assert.js';
+import concat from './internal/concat.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (x <> y) <> z = x <> (y <> z)
   associativity: assert.forall3 (x => y => z =>

--- a/src/Semigroupoid.js
+++ b/src/Semigroupoid.js
@@ -1,12 +1,10 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
-const compose = require ('./internal/compose_');
+import assert from './internal/assert.js';
+import compose from './internal/compose_.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  (x `compose` y) `compose` z = x `compose` (y `compose` z)
   associativity: assert.forall3 (x => y => z =>

--- a/src/Setoid.js
+++ b/src/Setoid.js
@@ -1,11 +1,9 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const assert = require ('./internal/assert');
+import assert from './internal/assert.js';
 
 
-module.exports = {
+export default {
 
   //  a `equals` a = true
   reflexivity: assert.forall1 (a =>

--- a/src/Traversable.js
+++ b/src/Traversable.js
@@ -1,16 +1,14 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const Compose = require ('./internal/Compose');
-const assert = require ('./internal/assert');
-const identity = require ('./internal/identity');
-const map = require ('./internal/map');
-const of = require ('./internal/of');
-const traverse = require ('./internal/traverse');
+import Compose from './internal/Compose.js';
+import assert from './internal/assert.js';
+import identity from './internal/identity.js';
+import map from './internal/map.js';
+import of from './internal/of.js';
+import traverse from './internal/traverse.js';
 
 
-module.exports = equals => ({
+export default equals => ({
 
   //  t (traverse F identity u) = traverse G t u
   naturality: assert.forall4 (F => G => t => u =>

--- a/src/internal/$.js
+++ b/src/internal/$.js
@@ -1,4 +1,2 @@
-'use strict';
-
 //  $ :: a -> (a -> b) -> b
-module.exports = x => f => f (x);
+export default x => f => f (x);

--- a/src/internal/Compose.js
+++ b/src/internal/Compose.js
@@ -1,16 +1,14 @@
-'use strict';
+import * as FL from 'fantasy-land';
+import show from 'sanctuary-show';
+import Z from 'sanctuary-type-classes';
 
-const FL = require ('fantasy-land');
-const show = require ('sanctuary-show');
-const Z = require ('sanctuary-type-classes');
-
-const ap = require ('./ap');
-const map = require ('./map');
-const of = require ('./of');
+import ap from './ap.js';
+import map from './map.js';
+import of from './of.js';
 
 
 //  Compose :: (Apply f, Apply g) => TypeRep f -> TypeRep g -> f (g a) -> Compose f g a
-module.exports = F => G => {
+export default F => G => {
   function Compose(value) {
     if (!(this instanceof Compose)) return new Compose (value);
     this.value = value;

--- a/src/internal/alt.js
+++ b/src/internal/alt.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  alt :: Alt f => f a -> f a -> f a
-module.exports = curry2 (Z.alt);
+export default curry2 (Z.alt);

--- a/src/internal/ap.js
+++ b/src/internal/ap.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  ap :: Apply f => f (a -> b) -> f a -> f b
-module.exports = curry2 (Z.ap);
+export default curry2 (Z.ap);

--- a/src/internal/assert.js
+++ b/src/internal/assert.js
@@ -1,34 +1,34 @@
-'use strict';
-
-const jsc = require ('jsverify');
+import jsc from 'jsverify';
 
 
-exports.forall1 = property => A => () => (
+const forall1 = property => A => () => (
   jsc.assert (
     jsc.forall (A, property)
   )
 );
 
-exports.forall2 = property => (A, B) => () => (
+const forall2 = property => (A, B) => () => (
   jsc.assert (
     jsc.forall (A, B, (a, b) => property (a) (b))
   )
 );
 
-exports.forall3 = property => (A, B, C) => () => (
+const forall3 = property => (A, B, C) => () => (
   jsc.assert (
     jsc.forall (A, B, C, (a, b, c) => property (a) (b) (c))
   )
 );
 
-exports.forall4 = property => (A, B, C, D) => () => (
+const forall4 = property => (A, B, C, D) => () => (
   jsc.assert (
     jsc.forall (A, B, C, D, (a, b, c, d) => property (a) (b) (c) (d))
   )
 );
 
-exports.forall5 = property => (A, B, C, D, E) => () => (
+const forall5 = property => (A, B, C, D, E) => () => (
   jsc.assert (
     jsc.forall (A, B, C, D, E, (a, b, c, d, e) => property (a) (b) (c) (d) (e))
   )
 );
+
+export default {forall1, forall2, forall3, forall4, forall5};

--- a/src/internal/bimap.js
+++ b/src/internal/bimap.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry3 = require ('./curry3');
+import curry3 from './curry3.js';
 
 //  bimap :: Bifunctor f => (a -> b) -> (c -> d) -> f a c -> f b d
-module.exports = curry3 (Z.bimap);
+export default curry3 (Z.bimap);

--- a/src/internal/chain.js
+++ b/src/internal/chain.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  chain :: Chain m => (a -> m b) -> m a -> m b
-module.exports = curry2 (Z.chain);
+export default curry2 (Z.chain);

--- a/src/internal/chainRec.js
+++ b/src/internal/chainRec.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry3 = require ('./curry3');
+import curry3 from './curry3.js';
 
 //  chainRec :: ChainRec m => TypeRep m -> ((a -> c, b -> c, a) -> m c) -> a -> m b
-module.exports = curry3 (Z.chainRec);
+export default curry3 (Z.chainRec);

--- a/src/internal/composeK.js
+++ b/src/internal/composeK.js
@@ -1,8 +1,6 @@
-'use strict';
-
-const chain = require ('./chain');
+import chain from './chain.js';
 
 //  composeK :: Chain m => (b -> m c) -> (a -> m b) -> a -> m c
 //
 //  Right-to-left Kleisli composition. Equivalent to Haskell's (<=<) function.
-module.exports = f => g => x => chain (f) (g (x));
+export default f => g => x => chain (f) (g (x));

--- a/src/internal/compose_.js
+++ b/src/internal/compose_.js
@@ -1,4 +1,2 @@
-'use strict';
-
 //  compose :: (b -> c) -> (a -> b) -> a -> c
-module.exports = f => g => x => f (g (x));
+export default f => g => x => f (g (x));

--- a/src/internal/concat.js
+++ b/src/internal/concat.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  concat :: Semigroup a => a -> a -> a
-module.exports = curry2 (Z.concat);
+export default curry2 (Z.concat);

--- a/src/internal/contramap.js
+++ b/src/internal/contramap.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  contramap :: Contravariant f => (b -> a) -> f a -> f b
-module.exports = curry2 (Z.contramap);
+export default curry2 (Z.contramap);

--- a/src/internal/curry2.js
+++ b/src/internal/curry2.js
@@ -1,4 +1,2 @@
-'use strict';
-
 //  curry2 :: ((a, b) -> c) -> a -> b -> c
-module.exports = f => x => y => f (x, y);
+export default f => x => y => f (x, y);

--- a/src/internal/curry3.js
+++ b/src/internal/curry3.js
@@ -1,4 +1,2 @@
-'use strict';
-
 //  curry3 :: ((a, b, c) -> d) -> a -> b -> c -> d
-module.exports = f => x => y => z => f (x, y, z);
+export default f => x => y => z => f (x, y, z);

--- a/src/internal/extend.js
+++ b/src/internal/extend.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  extend :: Extend w => (w a -> b) -> w a -> w b
-module.exports = curry2 (Z.extend);
+export default curry2 (Z.extend);

--- a/src/internal/extract.js
+++ b/src/internal/extract.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const Z = require ('sanctuary-type-classes');
+import Z from 'sanctuary-type-classes';
 
 //  extract :: Comonad w => w a -> a
-module.exports = Z.extract;
+export default Z.extract;

--- a/src/internal/filter.js
+++ b/src/internal/filter.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  filter :: Filterable f => (a -> Boolean) -> f a -> f a
-module.exports = curry2 (Z.filter);
+export default curry2 (Z.filter);

--- a/src/internal/id.js
+++ b/src/internal/id.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const Z = require ('sanctuary-type-classes');
+import Z from 'sanctuary-type-classes';
 
 //  id :: Category c => TypeRep c -> c
-module.exports = Z.id;
+export default Z.id;

--- a/src/internal/identity.js
+++ b/src/internal/identity.js
@@ -1,4 +1,2 @@
-'use strict';
-
 //  identity :: a -> a
-module.exports = x => x;
+export default x => x;

--- a/src/internal/invert.js
+++ b/src/internal/invert.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const Z = require ('sanctuary-type-classes');
+import Z from 'sanctuary-type-classes';
 
 //  invert :: Group g => g -> g
-module.exports = Z.invert;
+export default Z.invert;

--- a/src/internal/map.js
+++ b/src/internal/map.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  map :: Functor f => (a -> b) -> f a -> f b
-module.exports = curry2 (Z.map);
+export default curry2 (Z.map);

--- a/src/internal/of.js
+++ b/src/internal/of.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry2 = require ('./curry2');
+import curry2 from './curry2.js';
 
 //  of :: Applicative f => TypeRep f -> a -> f a
-module.exports = curry2 (Z.of);
+export default curry2 (Z.of);

--- a/src/internal/promap.js
+++ b/src/internal/promap.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry3 = require ('./curry3');
+import curry3 from './curry3.js';
 
 //  promap :: Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d
-module.exports = curry3 (Z.promap);
+export default curry3 (Z.promap);

--- a/src/internal/reduce.js
+++ b/src/internal/reduce.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry3 = require ('./curry3');
+import curry3 from './curry3.js';
 
 //  reduce :: Foldable f => ((b, a) -> b) -> b -> f a -> b
-module.exports = curry3 (Z.reduce);
+export default curry3 (Z.reduce);

--- a/src/internal/traverse.js
+++ b/src/internal/traverse.js
@@ -1,8 +1,6 @@
-'use strict';
+import Z from 'sanctuary-type-classes';
 
-const Z = require ('sanctuary-type-classes');
-
-const curry3 = require ('./curry3');
+import curry3 from './curry3.js';
 
 //  traverse :: (Applicative f, Traversable t) => TypeRep f -> (a -> f b) -> t a -> f (t b)
-module.exports = curry3 (Z.traverse);
+export default curry3 (Z.traverse);

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const L = require ('..');
-const Z = require ('sanctuary-type-classes');
+import L from '../index.js';
+import Z from 'sanctuary-type-classes';
 
 const ls = ((Object.keys (L)).sort ());
 const zs = ((Object.keys (Z)).sort ()).filter (k => Z[k]['@@type'] === 'sanctuary-type-classes/TypeClass@1');


### PR DESCRIPTION
Requiring dependants to use ES modules seems reasonable given that only test suites import this package.
