### PR TITLE
revert breaking change to ‘compose’

### DIFF
--- a/src/internal/compose_.js
+++ b/src/internal/compose_.js
@@ -1,2 +1,6 @@
-//  compose :: (b -> c) -> (a -> b) -> a -> c
-export default f => g => x => f (g (x));
+import Z from 'sanctuary-type-classes';
+
+import curry2 from './curry2.js';
+
+//  compose :: Semigroupoid c => c j k -> c i j -> c i k
+export default curry2 (Z.compose);


### PR DESCRIPTION
While converting the source code to ES6 (#30) I had the impression that `curry2 (Z.compose)` was being used to avoid defining `(b -> c) -> (a -> b) -> a -> c` via function expressions.

I now realize that Semigroupoid's associativity law depends on the more general `compose` function.
